### PR TITLE
fix typo in syllabus.tex

### DIFF
--- a/syllabus/syllabus.tex
+++ b/syllabus/syllabus.tex
@@ -148,7 +148,7 @@ of code written personally by the students.
 Higher grades will be given
 for better object-oriented practices used in the code. Lower grades will be
 given for the presence of static methods, NULLs, getters, setters, mutability,
-ORM, DTO, factories, type casting, and other anit-OOP practices (as suggested during the course).
+ORM, DTO, factories, type casting, and other anti-OOP practices (as suggested during the course).
 
 At the laboratory classes each group will have to present
 their projects three times with at least 14 calendar days interval between presentations.


### PR DESCRIPTION
`anit` -> `anti`